### PR TITLE
feat: logging+dev/ci improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,8 @@ RUN echo "LC_ALL=en_US.UTF-8" >> /etc/environment && \
 
 RUN apt-get -y install mariadb-client nginx 2>&1
 
-EXPOSE 8002:8002
+EXPOSE 80/tcp
 
-RUN mkdir /code
 WORKDIR /code
 
 # Doing this step before copying the whole codebase improves docker's ability to reuse cached layers at build time

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,9 +26,8 @@ RUN pip install -r requirements.txt
 
 COPY . /code/
 
-RUN mkdir /code/logs
-
-RUN mkdir /code/static
+RUN mkdir /code/logs && \
+    mkdir /code/static
 
 ENV DJANGO_SETTINGS_MODULE=ietf_guides.settings.prod
 

--- a/README.md
+++ b/README.md
@@ -73,5 +73,25 @@ docker run -it -v ${PWD}/logs:/code/logs -v ${PWD}/secrets/local.py:/code/ietf_g
 ```
 The website will then be exposed at http://localhost:8002
 
+### Running with docker-compose
+A docker compose stack is provided for testing. Although not suitable for production, this runs the IETF Guides app in production mode, plus a MariaDB database and a Mailpit instance to receive email. Settings should be adjusted via the `environment` section of the `app` service in `docker-compose.yml`.
+
+To start the application:
+```
+docker compose up --build --detach
+```
+This will bring up the containers. Due to a bug (as of 2026-02-27), on the first startup the `app` service restarts a few times while the `db` service initializes its database. After a few restarts, this should stabilize and the containers will run properly. 
+
+The app will be available on http://localhost:8002. The Mailpit is available on http://localhost:8026.
+To monitor server logs:
+```
+docker compose logs app -f
+```
+Note that the `app` container has its own snapshot of the workspace, it does not mount the dev directory. If you have made changes and want to update the running code, you can do:
+```
+docker compose up --build --detach
+```
+again and it will rebuild and recreate the `app` service.
+
 ### Dummy data
 running `./manage.py make_dummy_data` will create ten guides and ten participants with field values populated by Faker.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,58 @@
+# Copyright The IETF Trust 2026, All Rights Reserved
+#
+# Runs guides app, database, and a mailpit. Uses production mode.
+#
+# Known issues:
+#  - At first start, the app service initializes faster than the db service can
+#    start up and create its empty database. The `restart: unless-stopped` on the app
+#    service is a workaround. After a few restarts, the db is ready and app can then
+#    start up properly.
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    depends_on:
+      - db
+    ports:
+      - "8002:80"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      ADMINS: "admin@example.org"
+      ALLOWED_HOSTS: "*"
+      CSRF_TRUSTED_ORIGINS: "http://localhost:8002"
+      DB_HOST: "db"
+      DB_NAME: "guides"
+      DB_PASS: "abcd1234"
+      DB_PORT: "3306"
+      DB_SSLMODE: "PREFERRED"
+      DB_USER: "guides"
+      DEFAULT_FROM_EMAIL: "lead@guides.example.org"
+      EMAIL_HOST: "mailpit"
+      EMAIL_PORT: "1025"
+      HASHSALT: "wxyz0"
+      SECRET_KEY: "abcdef1234567890abcdef1234567890abcdef1234567890"
+    restart: unless-stopped
+
+  db:
+    image: mariadb:12
+    volumes:
+      - mariadb-data:/var/lib/mysql
+    restart: unless-stopped
+    environment:
+      MARIADB_USER: guides
+      MARIADB_PASSWORD: abcd1234
+      MARIADB_DATABASE: guides
+      MARIADB_ROOT_PASSWORD: dbrootpw
+
+  mailpit:
+    image: axllent/mailpit:v1.27
+    environment:
+      MP_DISABLE_VERSION_CHECK: true
+      MP_LABEL: GuidesMail
+    ports:
+      - "8026:8025"
+
+volumes:
+  mariadb-data:

--- a/docker-entry.sh
+++ b/docker-entry.sh
@@ -1,14 +1,9 @@
-#!/bin/sh
+#!/bin/bash
+set -e
 
 trap "echo TRAPed signal" HUP INT QUIT TERM
 
-if [ ! -f "/code/ietf_guides/settings/local.py" ]; then
-    echo "local.py not found. Exiting."
-    exit 1
-fi
-
-
-export DJANGO_SETTINGS_MODULE=ietf_guides.settings.prod
+export DJANGO_SETTINGS_MODULE=${DJANGO_SETTINGS_MODULE:-ietf_guides.settings.prod}
 
 /code/manage.py collectstatic --noinput
 /code/manage.py migrate --noinput

--- a/docker-entry.sh
+++ b/docker-entry.sh
@@ -9,6 +9,7 @@ export DJANGO_SETTINGS_MODULE=${DJANGO_SETTINGS_MODULE:-ietf_guides.settings.pro
 /code/manage.py migrate --noinput
 
 cp /code/nginx/default /etc/nginx/sites-enabled/default
+cp /code/nginx/00logging.conf /etc/nginx/conf.d/00logging.conf
 nginx
 
 gunicorn \

--- a/docker-entry.sh
+++ b/docker-entry.sh
@@ -11,6 +11,10 @@ export DJANGO_SETTINGS_MODULE=${DJANGO_SETTINGS_MODULE:-ietf_guides.settings.pro
 cp /code/nginx/default /etc/nginx/sites-enabled/default
 nginx
 
-gunicorn ietf_guides.wsgi:application --bind unix:/run/gunicorn.sock
+gunicorn \
+  -c /code/gunicorn.conf.py \
+  --bind unix:/run/gunicorn.sock \
+  ${GUNICORN_EXTRA_ARGS} \
+  ietf_guides.wsgi:application
 
 echo "exited $0"

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,0 +1,60 @@
+# Copyright The IETF Trust 2024-2026, All Rights Reserved
+"""gunicorn configuration"""
+import os
+
+# Worker config. If values are not present in the environment, uses defaults
+workers = int(os.environ.get("GUNICORN_WORKERS", "1"))
+max_requests = int(os.environ.get("GUNICORN_MAX_REQUESTS", "0"))
+timeout = int(os.environ.get("GUNICORN_TIMEOUT", "30"))
+
+# Logging config.
+loglevel = os.environ.get("GUNICORN_LOGLEVEL", "info")
+capture_output = True  # redirect stdout/stderr to errlog
+accesslog = "-"  # access log -> stdout
+
+# Log as JSON on stdout (to distinguish from Django's logs on stderr)
+#
+# This is applied as an update to gunicorn's glogging.CONFIG_DEFAULTS.
+logconfig_dict = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "root": {"level": "INFO", "handlers": ["console"]},
+    "loggers": {
+        "gunicorn.error": {
+            "level": "INFO",
+            "handlers": ["console"],
+            "propagate": False,
+            "qualname": "gunicorn.error",
+        },
+        "gunicorn.access": {
+            "level": "INFO",
+            "handlers": ["access_console"],
+            "propagate": False,
+            "qualname": "gunicorn.access",
+        },
+    },
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+            "formatter": "json",
+            "stream": "ext://sys.stdout",
+        },
+        "access_console": {
+            "class": "logging.StreamHandler",
+            "formatter": "access_json",
+            "stream": "ext://sys.stdout",
+        },
+    },
+    "formatters": {
+        "json": {
+            "class": "ietf_guides.utils.log.JsonFormatter",
+            "style": "{",
+            "format": "{asctime}{levelname}{message}{name}{process}",
+        },
+        "access_json": {
+            "class": "ietf_guides.utils.log.GunicornRequestJsonFormatter",
+            "style": "{",
+            "format": "{asctime}{levelname}{message}{name}{process}",
+        },
+    },
+}

--- a/ietf_guides/settings/base.py
+++ b/ietf_guides/settings/base.py
@@ -91,5 +91,3 @@ USE_X_FORWARDED_HOST = True
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
-
-from .local import *

--- a/ietf_guides/settings/dev.py
+++ b/ietf_guides/settings/dev.py
@@ -1,4 +1,5 @@
 from .base import *
+from .local import *
 
 DEBUG = True
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'

--- a/ietf_guides/settings/dev.py
+++ b/ietf_guides/settings/dev.py
@@ -1,3 +1,4 @@
+# Copyright The IETF Trust 2026, All Rights Reserved
 from .base import *
 from .local import *
 

--- a/ietf_guides/settings/prod.py
+++ b/ietf_guides/settings/prod.py
@@ -1,7 +1,9 @@
+# Copyright The IETF Trust 2026, All Rights Reserved
 import os
 from email.utils import parseaddr
 from .base import *  # noqa
 # n.b., does _not_ import from .local
+
 
 def _multiline_to_list(s):
     """Helper to split at newlines and convert to list"""
@@ -48,8 +50,47 @@ DATABASES = {
     },
 }
 
-# When running behind CloudFlare, X-Forwarded-Proto=https indicates the incoming connection was
-# secure. Use that to decide whether to use http or https as the scheme when constructing absolute
-# URLs instead of looking at the request.
+# When running behind CloudFlare, X-Forwarded-Proto=https indicates the incoming
+# connection was secure. Use that to decide whether to use http or https as the scheme
+# when constructing absolute URLs instead of looking at the request.
 # https://docs.djangoproject.com/en/5.0/ref/settings/#secure-proxy-ssl-header
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+
+
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    #
+    "loggers": {
+        "django": {
+            "handlers": ["console", "mail_admins"],
+            "level": "INFO",
+        },
+        "guides": {
+            "handlers": ["console"],
+            "level": "INFO",
+        },
+    },
+    "handlers": {
+        "console": {
+            "level": "DEBUG",
+            "class": "logging.StreamHandler",
+            "formatter": "json",
+        },
+        "mail_admins": {
+            "level": "ERROR",
+            "class": "django.utils.log.AdminEmailHandler",
+            "include_html": True,  # non-default
+        },
+    },
+    "formatters": {
+        "json": {
+            "class": "ietf_guides.utils.log.JsonFormatter",
+            "style": "{",
+            "format": (
+                "{asctime}{levelname}{message}{name}{pathname}{lineno}{funcName}"
+                "{process}"
+            ),
+        },
+    },
+}

--- a/ietf_guides/settings/prod.py
+++ b/ietf_guides/settings/prod.py
@@ -1,8 +1,55 @@
-from .base import *
+import os
+from email.utils import parseaddr
+from .base import *  # noqa
+# n.b., does _not_ import from .local
 
-EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+def _multiline_to_list(s):
+    """Helper to split at newlines and convert to list"""
+    return [item.strip() for item in s.split("\n") if item.strip()]
 
-# Your local.py should contain the credentials needed to send email through your selected SMTP
-# server. See <https://docs.djangoproject.com/en/2.1/topics/email/#obtaining-an-instance-of-an-email-backend>
 
+# SECURITY WARNING: keep the secret key used in production secret!
+SECRET_KEY = os.environ["SECRET_KEY"]
+assert not SECRET_KEY.startswith(
+    "django-insecure"
+)  # be sure we didn't get the dev secret
 
+HASHSALT = os.environ["HASHSALT"].strip()
+
+EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+EMAIL_HOST = os.environ["EMAIL_HOST"]
+EMAIL_PORT = int(os.environ["EMAIL_PORT"])
+DEFAULT_FROM_EMAIL = os.environ.get("DEFAULT_FROM_EMAIL", "lead@guides.ietf.org")
+
+_admins_str = os.environ.get("ADMINS", None)
+if _admins_str is not None:
+    ADMINS = [parseaddr(admin) for admin in _multiline_to_list(_admins_str)]
+else:
+    raise RuntimeError("ADMINS must be set")
+
+# ALLOWED_HOSTS is a newline-separated list of allowed hosts
+ALLOWED_HOSTS = _multiline_to_list(os.environ["ALLOWED_HOSTS"])
+
+# CSRF_TRUSTED_ORIGINS is a newline-separated list of allowed hosts
+CSRF_TRUSTED_ORIGINS = _multiline_to_list(os.environ["CSRF_TRUSTED_ORIGINS"])
+
+DATABASES = {
+    "default": {
+        "NAME": os.environ["DB_NAME"],
+        "HOST": os.environ["DB_HOST"],
+        "PORT": os.environ["DB_PORT"],
+        "ENGINE": "django.db.backends.mysql",
+        "USER": os.environ["DB_USER"],
+        "PASSWORD": os.environ["DB_PASS"],
+        "OPTIONS": {
+            "init_command": "SET sql_mode='STRICT_TRANS_TABLES'",
+            "ssl_mode": os.environ.get("DB_SSLMODE", "PREFERRED"),
+        },
+    },
+}
+
+# When running behind CloudFlare, X-Forwarded-Proto=https indicates the incoming connection was
+# secure. Use that to decide whether to use http or https as the scheme when constructing absolute
+# URLs instead of looking at the request.
+# https://docs.djangoproject.com/en/5.0/ref/settings/#secure-proxy-ssl-header
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")

--- a/ietf_guides/settings/test.py
+++ b/ietf_guides/settings/test.py
@@ -1,4 +1,5 @@
 from .base import *
+from .local import *
 
 EMAIL_BACKEND = 'django.core.mail.backends.locmem.EmailBackend'
 

--- a/ietf_guides/utils/log.py
+++ b/ietf_guides/utils/log.py
@@ -1,0 +1,47 @@
+# Copyright The IETF Trust 2024-2026, All Rights Reserved
+"""JSON Logger Utilities"""
+
+import logging
+import time
+
+from pythonjsonlogger.json import JsonFormatter as _JsonFormatter
+
+
+class JsonFormatter(_JsonFormatter):
+    """JSON formatter class with UTC timestamps and '.' decimal separators"""
+
+    converter = time.gmtime  # use UTC
+    default_msec_format = "%s.%03d"  # '.' instead of ','
+
+
+class GunicornRequestJsonFormatter(JsonFormatter):
+    """Only works with Gunicorn's logging"""
+
+    def add_fields(self, log_record, record, message_dict):
+        super().add_fields(log_record, record, message_dict)
+        log_record.setdefault("method", record.args["m"])
+        log_record.setdefault("proto", record.args["H"])
+        log_record.setdefault("remote_ip", record.args["h"])
+        path = record.args["U"]  # URL path
+        if record.args["q"]:  # URL query string
+            path = "?".join([path, record.args["q"]])
+        log_record.setdefault("path", path)
+        log_record.setdefault("status", record.args["s"])
+        log_record.setdefault("referer", record.args["f"])
+        log_record.setdefault("user_agent", record.args["a"])
+        log_record.setdefault("len_bytes", record.args["B"])
+        log_record.setdefault("duration_s", record.args["L"])  # decimal seconds
+        log_record.setdefault("host", record.args["{host}i"])
+        log_record.setdefault("x_request_start", record.args["{x-request-start}i"])
+        log_record.setdefault("x_forwarded_for", record.args["{x-forwarded-for}i"])
+        log_record.setdefault("x_forwarded_proto", record.args["{x-forwarded-proto}i"])
+        log_record.setdefault("cf_connecting_ip", record.args["{cf-connecting-ip}i"])
+        log_record.setdefault(
+            "cf_connecting_ipv6", record.args["{cf-connecting-ipv6}i"]
+        )
+        log_record.setdefault("cf_ray", record.args["{cf-ray}i"])
+
+
+class SimpleFormatter(logging.Formatter):
+    converter = time.gmtime  # use UTC
+    default_msec_format = "%s.%03d"  # "." instead of ","

--- a/nginx/00logging.conf
+++ b/nginx/00logging.conf
@@ -1,0 +1,20 @@
+# Define JSON log format - must be loaded before config that references it
+log_format  ietfjson  escape=json
+  '{'
+    '"asctime":"$time_iso8601",'
+    '"remote_ip":"$remote_addr",'
+    '"request":"$request",'
+    '"host":"$host",'
+    '"path":"$request_uri",'
+    '"method":"$request_method",'
+    '"status":"$status",'
+    '"len_bytes":"$body_bytes_sent",'
+    '"duration_s":"$request_time",'
+    '"referer":"$http_referer",'
+    '"user_agent":"$http_user_agent",'
+    '"x_forwarded_for":"$http_x_forwarded_for",'
+    '"x_forwarded_proto":"$http_x_forwarded_proto",'
+    '"cf_connecting_ip":"$http_cf_connecting_ip",'
+    '"cf_connecting_ipv6":"$http_cf_connecting_ipv6",'
+    '"cf_ray":"$http_cf_ray"'
+  '}';

--- a/nginx/default
+++ b/nginx/default
@@ -1,14 +1,38 @@
 server {
     listen 80 default_server;
     listen [::]:80 default_server;
+    server_name _;
 
-    location = /favicon.ico { access_log off; log_not_found off; }
+    error_log stderr crit;  # log to stderr (format not adjustable, so not JSON)
+
+    location /health/nginx {
+        access_log off;
+        return 200;
+    }
+
+    location = /favicon.ico {
+        access_log off;
+         log_not_found off;
+    }
+
     location /static/ {
+        # Replace default "main" formatter with the ietfjson formatter from nginx-logging.conf
+        access_log  /dev/stdout ietfjson;
+
         root /code;
     }
 
     location / {
-        include proxy_params;
+        proxy_set_header Host $host;
+        proxy_set_header Connection close;
+        proxy_set_header X-Request-Start "t=$msec";
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+        # Set timeouts longer than Cloudflare proxy limits
+        proxy_connect_timeout 60;  # nginx default (Cf = 15)
+        proxy_read_timeout 120;  # nginx default = 60 (Cf = 100)
+        proxy_send_timeout 60;  # nginx default = 60 (Cf = 30)
+        client_max_body_size 0;  # disable size check
         proxy_pass http://unix:/run/gunicorn.sock;
     }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pyquery>=1.2.13,!=1.2.14
 factory_boy>=2.11,<3
 gunicorn>=20.1.0
 mysqlclient>=2
+python-json-logger>=4.0.0


### PR DESCRIPTION
* Refactor settings to use values from the environment instead of `local.py` in production
* Add logging configuration for production
* Add a docker compose stack for running a "production" mode copy of the app for local testing
* Adjustments to the Dockerfile
* gunicorn logging / config
  - json access logs
  - expose gunicorn settings via env variables
* nginx logging / config
  - logs errors at the "crit" level
  - access logs for /statics only (app access logs come from gunicorn)
  - passes along cloudflare values for logging
